### PR TITLE
Add Google.es and Google.ad to the domain list

### DIFF
--- a/domains.js
+++ b/domains.js
@@ -1,6 +1,7 @@
 var targetPage = [
     "*://*.google.com/*",
     "*://*.google.ac/*",
+    "*://*.google.ad/*",
     "*://*.google.ae/*",
     "*://*.google.com.af/*",
     "*://*.google.com.ag/*",

--- a/domains.js
+++ b/domains.js
@@ -57,6 +57,7 @@ var targetPage = [
     "*://*.google.ee/*",
     "*://*.google.com.eg/*",
     "*://*.google.com.et/*",
+    "*://*.google.es/*",
     "*://*.google.eu/*",
     "*://*.google.fi/*",
     "*://*.google.com.fj",

--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,7 @@
         "*://*.google.ee/*",
         "*://*.google.com.eg/*",
         "*://*.google.com.et/*",
+        "*://*.google.es/*",
         "*://*.google.eu/*",
         "*://*.google.fi/*",
         "*://*.google.com.fj",

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
         "webRequest", "webRequestBlocking",
         "*://*.google.com/*",
         "*://*.google.ac/*",
+        "*://*.google.ad/*",
         "*://*.google.ae/*",
         "*://*.google.com.af/*",
         "*://*.google.com.ag/*",


### PR DESCRIPTION
Same as https://github.com/JonathanNakandala/Chrome-UA-for-Firefox-Android-on-Google/commit/0b5c0936ba4f490550533e8e34ca3d7ad3c71c9a but adding google.es (Spain) and google.ad (Andorra).