### PR TITLE
Use sync overwrite because it is much faster than the current async method

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,30 +12,29 @@ var ua = "Mozilla/5.0 (Linux; Android 6.0.1; SM-G928F Build/MMB29K) AppleWebKit/
 /*
 Rewrite the User-Agent header to "ua".
 */
-/*function rewriteUserAgentHeaderBlocking(e) {
-    console.log("something");
-    for (var header of e.requestHeaders) {
+function rewriteUserAgentHeaderBlocking(e) {
+    for (let header of e.requestHeaders) {
         if (header.name.toLowerCase() === "user-agent") {
             header.value = ua;
         }
     }
     return { requestHeaders: e.requestHeaders };
-}*/
-
-function rewriteUserAgentHeaderAsync(e) {
-    var asyncRewrite = new Promise((resolve, reject) => {
-        window.setTimeout(() => {
-            for (var header of e.requestHeaders) {
-                if (header.name.toLowerCase() === "user-agent") {
-                    header.value = ua;
-                }
-            }
-            resolve({ requestHeaders: e.requestHeaders });
-        }, 2000);
-    });
-
-    return asyncRewrite;
 }
+
+// function rewriteUserAgentHeaderAsync(e) {
+//     var asyncRewrite = new Promise((resolve, reject) => {
+//         window.setTimeout(() => {
+//             for (var header of e.requestHeaders) {
+//                 if (header.name.toLowerCase() === "user-agent") {
+//                     header.value = ua;
+//                 }
+//             }
+//             resolve({ requestHeaders: e.requestHeaders });
+//         }, 2000);
+//     });
+
+//     return asyncRewrite;
+// }
 
 /*
 Add rewriteUserAgentHeader as a listener to onBeforeSendHeaders,
@@ -43,4 +42,4 @@ only for the target page.
 
 Make it "blocking" so we can modify the headers.
 */
-browser.webRequest.onBeforeSendHeaders.addListener(rewriteUserAgentHeaderAsync, { urls: targetPage }, ["blocking", "requestHeaders"]);
+browser.webRequest.onBeforeSendHeaders.addListener(rewriteUserAgentHeaderBlocking, { urls: targetPage }, ["blocking", "requestHeaders"]);


### PR DESCRIPTION
First off thank you for making this extension! I didn't even know that Google had a better mobile version of their page and I'm so glad I can now get it on Firefox. I did notice that the time taken for a search to run increases when using the extension to about 5 seconds, on my phone anyway. 

Is there a reason the async header overwrite method was used rather than the synchronous one? The browser will have to block the request until the overwrite has happened, so any timeout will be blocking the whole page load (in this use case). Even if the async method does need to be used for some reason a two second timeout seems very large.  

I have tried using the sync method on my phone and it seems to work brilliantly. I think the extension should be updated to use that, or if you did find a problem with the sync method that I do not know about could the timeout maybe be changed to only 10ms or something? 